### PR TITLE
Fix docker build platform

### DIFF
--- a/apps/bff/project.json
+++ b/apps/bff/project.json
@@ -75,7 +75,7 @@
     },
     "docker-build": {
       "dependsOn": ["build"],
-      "command": "docker build -f apps/bff/Dockerfile . -t bff"
+      "command": "docker buildx build --platform=linux/amd64 -f apps/bff/Dockerfile . -t bff"
     }
   },
   "tags": []

--- a/apps/bff/tsconfig.app.json
+++ b/apps/bff/tsconfig.app.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["fastify-tsconfig", "./tsconfig.json"],
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",


### PR DESCRIPTION
Enforces docker image to be created for linux/amd64 platform as opposed to arm on some machines (i.e. apple silicon).